### PR TITLE
Increment curOpen only after originalOpenSync succeeds

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -69,8 +69,9 @@ function open (path, flags, mode, cb) {
 }
 
 fs.openSync = function (path, flags, mode) {
+  var fd = originalOpenSync.call(fs, path, flags, mode)
   curOpen ++
-  return originalOpenSync.call(fs, path, flags, mode)
+  return fd
 }
 
 function onclose () {


### PR DESCRIPTION
If an exception happens calling `fs.openSync`, the `curOpen` counter is incremented, but never decremented.  This can cause asynchronous fs methods to hang if enough exceptions happen opening files synchronously.

E.g.

```
var fs = require('graceful-fs');

for(var i = 0; i < fs.MAX_OPEN; ++i) {
  try {
    fs.readFileSync('i-do-not-exist');                  
  } catch(e) {}
}

// This readFile is queued up because curOpen == fs.MAX_OPEN, but it never gets executed
fs.readFile(__filename, function(e, contents) {
  console.log('This callback should be called');
});
```
