### PR TITLE
Ensure curOpen decrements if open call fails.

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -70,7 +70,11 @@ function open (path, flags, mode, cb) {
 
 fs.openSync = function (path, flags, mode) {
   curOpen ++
-  return originalOpenSync.call(fs, path, flags, mode)
+  try {
+    return originalOpenSync.call(fs, path, flags, mode)
+  } catch (e) {
+      curOpen --
+  }
 }
 
 function onclose () {


### PR DESCRIPTION
Without this patch some uses of glob.js, which brings in graceful-fs, will hang during file operations.

This patch fixes https://github.com/isaacs/node-glob/issues/46 based on my testing.
