### PR TITLE
Specify mkdirp dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mkdirp": "~0.3.4"
+  },
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
`mkdirp` is required since ff11bee7df918db21e351ddb336aaf094e54a3bc. Require it in package.json.
