### PR TITLE
if on windows, requeue a file if the error has an OK status as well

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -1,7 +1,6 @@
 // Monkey-patching the fs module.
 // It's ugly, but there is simply no other way to do this.
 var fs = module.exports = require('fs')
-var os = require('os')
 
 var assert = require('assert')
 
@@ -127,7 +126,7 @@ function Req () {
 }
 
 Req.prototype.done = function (er, result) {
-  if (er && (er.code === "EMFILE" || (os.platform() === "win32" && er.code === "OK"))) {
+  if (er && (er.code === "EMFILE" || (process.platform === "win32" && er.code === "OK"))) {
     this.failures ++
     enqueue(this)
   } else {


### PR DESCRIPTION
Retry when we get an OK status on Windows.

This is occuring for me on Windows 8 64bit, and for <a href="http://stackoverflow.com/questions/16425458/error-ok-when-using-fs-readfile-in-node-js-after-some-iteration-of-about-a">this guy</a> on Windows 7 64bit.
