### PR TITLE
Remove return from fs.js

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -8,4 +8,4 @@ var post = '});'
 var src = pre + process.binding('natives').fs + post
 var vm = require('vm')
 var fn = vm.runInThisContext(src)
-return fn(exports, require, module, __filename, __dirname)
+fn(exports, require, module, __filename, __dirname)


### PR DESCRIPTION
The return isn't necessary for the monkey patching that's going on here.
Node is totally fine with it, but other tools (like esprima) throw parse
errors when they see an invalid return like that.
