### PR TITLE
Fix horrible process.binding() atrocity

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -1,11 +1,1 @@
-// eeeeeevvvvviiiiiiillllll
-// more evil than monkey-patching the native builtin?
-// Not sure.
-
-var mod = require("module")
-var pre = '(function (exports, require, module, __filename, __dirname) { '
-var post = '});'
-var src = pre + process.binding('natives').fs + post
-var vm = require('vm')
-var fn = vm.runInThisContext(src)
-fn(exports, require, module, __filename, __dirname)
+module.exports = Object.create(require('fs'))

--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -1,5 +1,3 @@
-// Monkey-patching the fs module.
-// It's ugly, but there is simply no other way to do this.
 var fs = module.exports = require('./fs.js')
 
 var assert = require('assert')

--- a/test/module-evil-hackery.js
+++ b/test/module-evil-hackery.js
@@ -1,0 +1,10 @@
+var test = require('tap').test
+var realfs = require('fs')
+var fs = require('../')
+
+test('module assignment should not leak', function (t) {
+    t.plan(1)
+
+    fs.abc = 3
+    t.equal(realfs.abc, undefined)
+})

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,0 +1,12 @@
+var test = require('tap').test
+var fs = require('fs')
+var gfs = require('../graceful-fs.js')
+
+test('graceful fs uses same stats constructor as fs', function (t) {
+  t.equal(gfs.Stats, fs.Stats, 'should reference the same constructor')
+  t.ok(fs.statSync(__filename) instanceof fs.Stats,
+    'should be instance of fs.Stats')
+  t.ok(gfs.statSync(__filename) instanceof fs.Stats,
+    'should be instance of fs.Stats')
+  t.end()
+})


### PR DESCRIPTION
See https://github.com/nodejs/io.js/pull/2026. Also fixes https://github.com/isaacs/node-graceful-fs/issues/35.

This may introduce an issue, as it moves some functions like `fs.rename` to the prototype of `graceful-fs` rather than the actual object. I'd recommend just pushing out a semver-major release, because fixing the `process.binding` is much more pressing than the location of functions on the prototype chain.