### PR TITLE
amazing-graceful-fs + fixups for 0.8

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -4,6 +4,14 @@ module.exports = require('./fs.js')
 // fix up some busted stuff, mostly on windows and old nodes
 require('./polyfills.js')
 
+module.exports.open = open
+
+if (process.version.substr(0, 4) === 'v0.8') {
+  var legacy = require('./legacy-streams.js')
+  ReadStream = legacy.ReadStream
+  WriteStream = legacy.WriteStream
+}
+
 module.exports.FileReadStream = ReadStream;  // Legacy name.
 module.exports.FileWriteStream = WriteStream;  // Legacy name.
 module.exports.ReadStream = ReadStream
@@ -12,7 +20,6 @@ module.exports.close = close
 module.exports.closeSync = closeSync
 module.exports.createReadStream = createReadStream
 module.exports.createWriteStream = createWriteStream
-module.exports.open = open
 module.exports.readFile = readFile
 module.exports.readdir = readdir
 

--- a/legacy-streams.js
+++ b/legacy-streams.js
@@ -1,0 +1,113 @@
+var Stream = require('stream').Stream
+var open = require('./fs').open
+
+module.exports.ReadStream = ReadStream
+module.exports.WriteStream = WriteStream
+
+function ReadStream (path, options) {
+  if (!(this instanceof ReadStream)) return new ReadStream(path, options);
+
+  Stream.call(this);
+
+  var self = this;
+
+  this.path = path;
+  this.fd = null;
+  this.readable = true;
+  this.paused = false;
+
+  this.flags = 'r';
+  this.mode = 438; /*=0666*/
+  this.bufferSize = 64 * 1024;
+
+  options = options || {};
+
+  // Mixin options into this
+  var keys = Object.keys(options);
+  for (var index = 0, length = keys.length; index < length; index++) {
+    var key = keys[index];
+    this[key] = options[key];
+  }
+
+  if (this.encoding) this.setEncoding(this.encoding);
+
+  if (this.start !== undefined) {
+    if ('number' !== typeof this.start) {
+      throw TypeError('start must be a Number');
+    }
+    if (this.end === undefined) {
+      this.end = Infinity;
+    } else if ('number' !== typeof this.end) {
+      throw TypeError('end must be a Number');
+    }
+
+    if (this.start > this.end) {
+      throw new Error('start must be <= end');
+    }
+
+    this.pos = this.start;
+  }
+
+  if (this.fd !== null) {
+    process.nextTick(function() {
+      self._read();
+    });
+    return;
+  }
+
+  open(this.path, this.flags, this.mode, function (err, fd) {
+    if (err) {
+      self.emit('error', err);
+      self.readable = false;
+      return;
+    }
+
+    self.fd = fd;
+    self.emit('open', fd);
+    self._read();
+  })
+};
+
+function WriteStream (path, options) {
+  if (!(this instanceof WriteStream)) return new WriteStream(path, options);
+
+  Stream.call(this);
+
+  this.path = path;
+  this.fd = null;
+  this.writable = true;
+
+  this.flags = 'w';
+  this.encoding = 'binary';
+  this.mode = 438; /*=0666*/
+  this.bytesWritten = 0;
+
+  options = options || {};
+
+  // Mixin options into this
+  var keys = Object.keys(options);
+  for (var index = 0, length = keys.length; index < length; index++) {
+    var key = keys[index];
+    this[key] = options[key];
+  }
+
+  if (this.start !== undefined) {
+    if ('number' !== typeof this.start) {
+      throw TypeError('start must be a Number');
+    }
+    if (this.start < 0) {
+      throw new Error('start must be >= zero');
+    }
+
+    this.pos = this.start;
+  }
+
+  this.busy = false;
+  this._queue = [];
+
+  if (this.fd === null) {
+    this._open = open;
+    this._queue.push([this._open, this.path, this.flags, this.mode, undefined]);
+    this.flush();
+  }
+}


### PR DESCRIPTION
meant to be used in combination with #45 adding 0.8 support

0.8 uses streams1 so it does not have an `open` method. I simply copied and pasted the constructor contents.

https://github.com/joyent/node/blob/v0.8.22/lib/fs.js#L1221-L1283

the lines changed in the constructors are legacy-streams.js: 59 and 110 -- to use the fs.open from gfs.
