### PR TITLE
Fix number of arguments of chmod/own cb

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -206,9 +206,9 @@ function patchLutimes (fs) {
 function chmodFix (orig) {
   if (!orig) return orig
   return function (target, mode, cb) {
-    return orig.call(fs, target, mode, function (er, res) {
+    return orig.call(fs, target, mode, function (er) {
       if (chownErOk(er)) er = null
-      if (cb) cb(er, res)
+      if (cb) cb.apply(this, arguments)
     })
   }
 }
@@ -228,9 +228,9 @@ function chmodFixSync (orig) {
 function chownFix (orig) {
   if (!orig) return orig
   return function (target, uid, gid, cb) {
-    return orig.call(fs, target, uid, gid, function (er, res) {
+    return orig.call(fs, target, uid, gid, function (er) {
       if (chownErOk(er)) er = null
-      if (cb) cb(er, res)
+      if (cb) cb.apply(this, arguments)
     })
   }
 }


### PR DESCRIPTION
The number of arguments passed to the callback in chmod was changed with v4.1.5.
This release broke, for example, the following snippet of code that worked in v4.1.4:

```javascript
async.waterfall([
          function(next) {
            fs.chmod(fileName, '755', next);
          },
          function(next) {
            // next in v4.1.5 is undefined while in v4.1.4 is not
          }
        ], cb);
```
