### PR TITLE
V3 eval better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+coverage/
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: node_js
+node_js:
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '6'

--- a/fs.js
+++ b/fs.js
@@ -6,27 +6,6 @@ var mod = require("module")
 var pre = '(function (exports, require, module, __filename, __dirname) { '
 var post = '});'
 var src = pre + process.binding('natives').fs + post
-var deprecation = ''
-
-var printDeprecation = ['var prefix = \'(\' + [process.release.name, process.pid].join(\':\') + \')\';',
-'var printDeprecation = function(msg, warned) {',
-'  if (process.noDeprecation)',
-'    return true;',
-'  if (warned)',
-'    return warned;',
-'  if (process.throwDeprecation)',
-'    throw new Error(prefix + msg);',
-'  else if (process.traceDeprecation)',
-'    console.trace(msg);',
-'  else',
-'    console.error(prefix + msg);',
-'  return true;',
-'};'].join('\n');
-
-var deprecrationRequire = /const printDeprecation = require\(\'internal\/util\'\).printDeprecationMessage;/
-
-src = src.replace(deprecrationRequire, printDeprecation);
-
 var vm = require('vm')
 var fn = vm.runInThisContext(src)
 fn(exports, require, module, __filename, __dirname)

--- a/fs.js
+++ b/fs.js
@@ -1,11 +1,1 @@
-// eeeeeevvvvviiiiiiillllll
-// more evil than monkey-patching the native builtin?
-// Not sure.
-
-var mod = require("module")
-var pre = '(function (exports, require, module, __filename, __dirname) { '
-var post = '});'
-var src = pre + process.binding('natives').fs + post
-var vm = require('vm')
-var fn = vm.runInThisContext(src)
-fn(exports, require, module, __filename, __dirname)
+module.exports = require('natives').require('fs')

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8",
     "tap": "^1.2.0"
+  },
+  "dependencies": {
+    "natives": "^1.0.1"
   }
 }


### PR DESCRIPTION
So, the problem with re-evaluating Node's fs source is that some stuff got moved to `internal/`.

This adds support for re-evaluating Node.js modules that use `internal/` modules by leveraging the [natives](http://npm.im/natives) module.

This avoids the need for reggae (or any kind of music, for that matter), and will not be as likely to be broken when future bits of Node's internals move around.

Works in Node v0.8 through master, and supports changes planned (afaik) in v7.  I expect that this will support gulp's needs.

cc: @thealphanerd @phated