### PR TITLE
add missing fs.readdir encoding option

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -128,15 +128,15 @@ function patch (fs) {
   var fs$readdir = fs.readdir
   fs.readdir = readdir
   function readdir (path, cb) {
-    return go$readdir(path, cb)
+    return arguments.length === 2 ? go$readdir(path, "utf8", cb) : go$readdir(path, encoding, cb)
 
     function go$readdir () {
-      return fs$readdir(path, function (err, files) {
+      return fs$readdir(path, encoding, function (err, files) {
         if (files && files.sort)
           files.sort();  // Backwards compatibility with graceful-fs.
 
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$readdir, [path, cb]])
+          enqueue([go$readdir, [path, encoding, cb]])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)

--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -127,8 +127,8 @@ function patch (fs) {
 
   var fs$readdir = fs.readdir
   fs.readdir = readdir
-  function readdir (path, cb) {
-    return arguments.length === 2 ? go$readdir(path, "utf8", cb) : go$readdir(path, encoding, cb)
+  function readdir (path, encoding, cb) {
+    return arguments.length === 2 ? go$readdir(path, "utf8", encoding) : go$readdir(path, encoding, cb)
 
     function go$readdir () {
       return fs$readdir(path, encoding, function (err, files) {


### PR DESCRIPTION
fs.readdir has optional option called encoding:
https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback