### PR TITLE
Always make `fs.Stats`’ `.uid` and `.gid` fields unsigned

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -56,6 +56,14 @@ function patch (fs) {
   fs.fchmodSync = chmodFixSync(fs.fchmodSync)
   fs.lchmodSync = chmodFixSync(fs.lchmodSync)
 
+  fs.stat = statFix(fs.stat)
+  fs.fstat = statFix(fs.fstat)
+  fs.lstat = statFix(fs.lstat)
+
+  fs.statSync = statFixSync(fs.statSync)
+  fs.fstatSync = statFixSync(fs.fstatSync)
+  fs.lstatSync = statFixSync(fs.lstatSync)
+
   // if lchmod/lchown do not exist, then make them no-ops
   if (!fs.lchmod) {
     fs.lchmod = function (path, mode, cb) {
@@ -243,6 +251,32 @@ function chownFixSync (orig) {
     } catch (er) {
       if (!chownErOk(er)) throw er
     }
+  }
+}
+
+
+function statFix (orig) {
+  if (!orig) return orig
+  // Older versions of Node erroneously returned signed integers for
+  // uid + gid.
+  return function (target, cb) {
+    return orig.call(fs, target, function (er, stats) {
+      if (stats.uid < 0) stats.uid += 0x100000000
+      if (stats.gid < 0) stats.gid += 0x100000000
+      if (cb) cb.apply(this, arguments)
+    })
+  }
+}
+
+function statFixSync (orig) {
+  if (!orig) return orig
+  // Older versions of Node erroneously returned signed integers for
+  // uid + gid.
+  return function (target) {
+    var stats = orig.call(fs, target)
+    if (stats.uid < 0) stats.uid += 0x100000000
+    if (stats.gid < 0) stats.gid += 0x100000000
+    return stats;
   }
 }
 

--- a/test/stats-uid-gid.js
+++ b/test/stats-uid-gid.js
@@ -1,0 +1,29 @@
+'use strict';
+var test = require('tap').test
+var util = require('util')
+var fs = require('fs')
+
+// mock fs.statSync to return signed uids/gids
+var realStatSync = fs.statSync
+fs.statSync = function(path) {
+  var stats = realStatSync.call(fs, path)
+  stats.uid = -2
+  stats.gid = -2
+  return stats
+}
+
+var gfs = require('../graceful-fs.js')
+
+test('graceful fs uses same stats constructor as fs', function (t) {
+  t.equal(gfs.Stats, fs.Stats, 'should reference the same constructor')
+
+  if (!process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH) {
+    t.equal(fs.statSync(__filename).uid, -2)
+    t.equal(fs.statSync(__filename).gid, -2)
+  }
+
+  t.equal(gfs.statSync(__filename).uid, 0xfffffffe)
+  t.equal(gfs.statSync(__filename).gid, 0xfffffffe)
+
+  t.end()
+})


### PR DESCRIPTION
At the time of writing, all currently published versions of Node.js return signed 32-bit integers in their return values for the `uid` and `gid` fields of `fs.Stats` instances.

This is problematic, because some of Node’s other `fs` methods like `chown` expect unsigned 32-bit integer input and throw when encountering negative integers; this has broken e.g. `sudo npm install -g` on `OS X`, where `nobody` has a UID that would be returned as `-2` by `fs.stat()`.

Ref: https://github.com/nodejs/node/pull/8515
Ref: https://github.com/npm/npm/issues/13918