### PR TITLE
Test guarded access to `stats` in `fs.statSync()` wrapper

### DIFF
--- a/test/stats-uid-gid.js
+++ b/test/stats-uid-gid.js
@@ -29,9 +29,16 @@ test('graceful fs uses same stats constructor as fs', function (t) {
 })
 
 test('does not throw when async stat fails', function (t) {
-  fs.stat(__filename + ' this does not exist', function (er, stats) {
+  gfs.stat(__filename + ' this does not exist', function (er, stats) {
     t.ok(er)
     t.notOk(stats)
     t.end()
   })
+})
+
+test('does not throw when async stat fails', function (t) {
+  t.throws(function() {
+    gfs.statSync(__filename + ' this does not exist')
+  }, /ENOENT/)
+  t.end()
 })


### PR DESCRIPTION
~~f5287299ae67d introduced a bug in which `fs.stat()` would crash when the underlying call failed, because the accessing `uid` and `gid` fields of the resulting `stats` struct was attempted, which is `undefined` for failing calls.~~

Sorry! :(

Adds extra test that’s left over from an attempted alternative to 14aaa19.