### PR TITLE
Wait longer for rename lock contention to resolve

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -80,15 +80,27 @@ function patch (fs) {
 
   // on Windows, A/V software can lock the directory, causing this
   // to fail with an EACCES or EPERM if the directory contains newly
-  // created files.  Try again on failure, for up to 1 second.
+  // created files.  Try again on failure, for up to 60 seconds.
+
+  // Set the timeout this long because some Windows Anti-Virus, such as Parity
+  // bit9, may lock files for up to a minute, causing npm package install
+  // failures. Also, take care to yield the scheduler. Windows scheduling gives
+  // CPU to a busy looping process, which can cause the program causing the lock
+  // contention to be starved of CPU by node, so the contention doesn't resolve.
   if (process.platform === "win32") {
     fs.rename = (function (fs$rename) { return function (from, to, cb) {
       var start = Date.now()
+      var backoff = 0;
       fs$rename(from, to, function CB (er) {
         if (er
             && (er.code === "EACCES" || er.code === "EPERM")
-            && Date.now() - start < 1000) {
-          return fs$rename(from, to, CB)
+            && Date.now() - start < 60000) {
+          setTimeout(function() {
+            fs$rename(from, to, CB);
+          }, backoff)
+          if (backoff < 100)
+            backoff += 10;
+          return;
         }
         if (cb) cb(er)
       })


### PR DESCRIPTION
Anti-virus software on Windows can lock files for long periods of time,
and graceful-fs was only waiting up to a second, and busy-looping during
that wait, which has the potential to starve the locker of CPU.

Fixes https://github.com/npm/npm/issues/12059
