### PR TITLE
Ebusy retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 .nyc_output/
+.idea/

--- a/polyfills.js
+++ b/polyfills.js
@@ -96,7 +96,7 @@ function patch (fs) {
       var backoff = 0;
       fs$rename(from, to, function CB (er) {
         if (er
-            && (er.code === "EACCES" || er.code === "EPERM")
+            && (er.code === "EACCES" || er.code === "EPERM" || er.code === "EBUSY")
             && Date.now() - start < 60000) {
           setTimeout(function() {
             fs.stat(to, function (stater, st) {


### PR DESCRIPTION
win32: retry rename on EBUSY, as we do for EPERM and EACCESS

EBUSY can occur when resources are locked by applications (ex. Dropbox, AV). it seems sensible to retry in this scenario too. the behavior is consistent with rimraf (https://github.com/isaacs/rimraf)

resolves #127