### PR TITLE
Fix ReadSteam and WriteStream being undefined

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -162,11 +162,11 @@ function patch (fs) {
     WriteStream = legStreams.WriteStream
   }
 
-  var fs$ReadStream = fs.ReadStream
+  var fs$ReadStream = fs.createReadStream
   ReadStream.prototype = Object.create(fs$ReadStream.prototype)
   ReadStream.prototype.open = ReadStream$open
 
-  var fs$WriteStream = fs.WriteStream
+  var fs$WriteStream = fs.createWriteStream
   WriteStream.prototype = Object.create(fs$WriteStream.prototype)
   WriteStream.prototype.open = WriteStream$open
 


### PR DESCRIPTION
This change fixes _TypeError: fs$ReadStream is undefined_ that occurs mostly when starting a project with **Create-react-app**.
Namely, it fixes: 

- #109 
- #121
- #126