### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/test/readdir-options.js
+++ b/test/readdir-options.js
@@ -4,7 +4,11 @@ var fs = require("fs")
 var currentTest
 
 var strings = ['b', 'z', 'a']
-var buffs = strings.map(function (s) { return new Buffer(s) })
+var buffs = strings.map(function (s) {
+  return Buffer.from && Buffer.from !== Uint8Array.from
+    ? Buffer.from(s)
+    : new Buffer(s)
+})
 var hexes = buffs.map(function (b) { return b.toString('hex') })
 
 function getRet (encoding) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/605
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor