### PR TITLE
Avoid crash when fs is not available

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -60,7 +60,7 @@ module.exports.closeSync = (function (fs$closeSync) { return function (fd) {
 // We look for the string `graceful-fs` from the comment above. This
 // way we are not adding any extra properties and it will detect if older
 // versions of graceful-fs are installed.
-if (!/\bgraceful-fs\b/.test(fs.closeSync.toString())) {
+if (fs.closeSync && !/\bgraceful-fs\b/.test(fs.closeSync.toString())) {
   fs.closeSync = module.exports.closeSync;
   fs.close = module.exports.close;
 }


### PR DESCRIPTION
I am trying to generate Excel file in browser using React Typescript.
I am using exceljs library, and it depends on node-graceful-fs
dependency:  exceljs#node-unzip-2#fstream#graceful-fs
But loading graceful-fs crashed because fs is not available in Browser.

I do not expect fs nor graceful-fs to run in browser.
I just want to avoid crash in startup sequence.
