### PR TITLE
Support stat options argument

### DIFF
--- a/test/enoent.js
+++ b/test/enoent.js
@@ -3,6 +3,30 @@
 
 var t = require('tap')
 var g = require('../')
+
+var NODE_VERSION_MAJOR_WITH_BIGINT = 10
+var NODE_VERSION_MINOR_WITH_BIGINT = 5
+var NODE_VERSION_PATCH_WITH_BIGINT = 0
+var nodeVersion = process.versions.node.split('.')
+var nodeVersionMajor = Number.parseInt(nodeVersion[0], 10)
+var nodeVersionMinor = Number.parseInt(nodeVersion[1], 10)
+var nodeVersionPatch = Number.parseInt(nodeVersion[2], 10)
+
+function nodeSupportsBigInt () {
+  if (nodeVersionMajor > NODE_VERSION_MAJOR_WITH_BIGINT) {
+    return true
+  } else if (nodeVersionMajor === NODE_VERSION_MAJOR_WITH_BIGINT) {
+    if (nodeVersionMinor > NODE_VERSION_MINOR_WITH_BIGINT) {
+      return true
+    } else if (nodeVersionMinor === NODE_VERSION_MINOR_WITH_BIGINT) {
+      if (nodeVersionPatch >= NODE_VERSION_PATCH_WITH_BIGINT) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 var file = 'this file does not exist even a little bit'
 var methods = [
   ['open', 'r'],
@@ -17,6 +41,13 @@ var methods = [
 if (process.version.match(/^v([6-9]|[1-9][0-9])\./)) {
   methods.push(['readdir', {}])
 }
+
+// any version > v10.5 can do stat(path, options, cb)
+if (nodeSupportsBigInt()) {
+  methods.push(['stat', {}])
+  methods.push(['lstat', {}])
+}
+
 
 t.plan(methods.length)
 methods.forEach(function (method) {


### PR DESCRIPTION
`fs.stat` accepts an optional options object since Node.js v10.5.0 (`fs.stat(path[, options], callback)`).

This PR tries to adapt the `statFix` polyfill to handle three arguments instead of two.

Unfortunately the tests are failing because when the environment variable `TEST_GRACEFUL_FS_GLOBAL_PATCH` is set, `fs` will be patched through the `graceful-fs` dependency of `tap` instead of the `graceful-fs` version under test (I'll open a separate issue for that).

@isaacs @manidlou is this going in the right direction?