### PR TITLE
WIP: Add conditional support for gfs.promises.

### DIFF
--- a/test/stats.js
+++ b/test/stats.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+var util = require('util')
 var gfs = require('../graceful-fs.js')
 var test = require('tap').test
 
@@ -9,4 +10,16 @@ test('graceful fs uses same stats constructor as fs', function (t) {
   t.ok(gfs.statSync(__filename) instanceof fs.Stats,
     'should be instance of fs.Stats')
   t.end()
+})
+
+test('graceful fs promises.stat', { skip: !util.promisify }, function (t) {
+  gfs.promises.stat(__filename)
+    .then(function (stat) {
+      t.ok(stat instanceof fs.Stats)
+      t.end()
+    })
+    .catch(function (error) {
+      t.error(error)
+      t.end()
+    })
 })


### PR DESCRIPTION
This support is dependent on `util.promisify` existing, so node.js 8+.

Fixes #160

---

@isaacs I think the code itself is complete, I want to seek feedback before I spend the time on more test coverage.  Of note unlike native `fs.promises`, reading the `gfs.promises` property will never produce an 'experimental' warning.  Additionally native `fs.promises` is not available in node.js 8 or 9, `gfs.promises` is available in those versions.  The list of functions that are promisified is from `Object.keys(require('fs').promises).sort()` in node.js 12.7.0.

One difference, `require('fs').promises` appears to be separate wrappers around internal functions.  So `fs.promises.stat` is not the result of `util.promisify(fs.stat)`.  Technically speaking the correct way to deal with this would be to reimplement all patched functions based directly on `fs.promises` but that seems like it would be a maintenance burden and would limit use of gfs.promises to the versions of node.js which provide fs.promises.  I'm not sure if there is someone from node.js we should ask if this makes an actual difference in any cases or if the node.js implementation does the same thing as util.promisify but with better performance.