### PR TITLE
Create/use global shared retry queue.

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -54,7 +54,9 @@ if (!global[gracefulQueue]) {
       })
     }
 
-    close[previous] = fs$close
+    Object.defineProperty(close, previous, {
+      value: fs$close
+    })
     return close
   })(fs.close)
 
@@ -65,7 +67,9 @@ if (!global[gracefulQueue]) {
       retry()
     }
 
-    closeSync[previous] = fs$closeSync
+    Object.defineProperty(closeSync, previous, {
+      value: fs$closeSync
+    })
     return closeSync
   })(fs.closeSync)
 

--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -5,7 +5,15 @@ var clone = require('./clone.js')
 
 var util = require('util')
 
-var gracefulQueue = Symbol.for('graceful-fs.queue')
+var gracefulQueue
+var previous
+if (typeof Symbol === 'function' && typeof Symbol.for === 'function') {
+  gracefulQueue = Symbol.for('graceful-fs.queue')
+  previous = Symbol.for('graceful-fs.previous')
+} else {
+  gracefulQueue = '@@symbol@@graceful-fs.queue'
+  previous = '@@symbol@@graceful-fs.previous'
+}
 
 function noop () {}
 
@@ -28,9 +36,6 @@ if (!global[gracefulQueue]) {
       return queue
     }
   })
-
-  // This is used in testing by future versions
-  var previous = Symbol.for('graceful-fs.previous')
 
   // Patch fs.close/closeSync to shared queue version, because we need
   // to retry() whenever a close happens *anywhere* in the program.

--- a/test/close.js
+++ b/test/close.js
@@ -1,10 +1,22 @@
-var fs$close = require('fs').close;
-var fs$closeSync = require('fs').closeSync;
-var fs = require('../');
+var fs = require('fs')
+var path = require('path')
+var gfsPath = path.resolve(__dirname, '..', 'graceful-fs.js')
+var gfs = require(gfsPath)
+var importFresh = require('import-fresh')
+var fs$close = fs.close
+var fs$closeSync = fs.closeSync
 var test = require('tap').test
 
 test('`close` is patched correctly', function(t) {
-  t.notEqual(fs.close, fs$close, 'patch close');
-  t.notEqual(fs.closeSync, fs$closeSync, 'patch closeSync');
+  t.match(fs$close.toString(), /graceful-fs shared queue/, 'patch fs.close');
+  t.match(fs$closeSync.toString(), /graceful-fs shared queue/, 'patch fs.closeSync');
+  t.match(gfs.close.toString(), /graceful-fs shared queue/, 'patch gfs.close');
+  t.match(gfs.closeSync.toString(), /graceful-fs shared queue/, 'patch gfs.closeSync');
+
+  var newGFS = importFresh(gfsPath)
+  t.equal(fs.close, fs$close)
+  t.equal(fs.closeSync, fs$closeSync)
+  t.equal(newGFS.close, fs$close)
+  t.equal(newGFS.closeSync, fs$closeSync)
   t.end();
 })


### PR DESCRIPTION
Importing a fresh copy of graceful-fs then using `require('fs').close`
would only initiate retry of the queue from the first copy of
graceful-fs, so needed retries associated with subsequent instances of
graceful-fs would not be executed.