### PR TITLE
Support copyFile

### DIFF
--- a/test/write-then-read.js
+++ b/test/write-then-read.js
@@ -24,16 +24,31 @@ test('make files', function (t) {
   t.end();
 })
 
-test('read files', function (t) {
-  // now read them
-  t.plan(num)
+test('copy files', function (t) {
   for (var i = 0; i < num; ++i) {
-    fs.readFile(paths[i], 'ascii', function(err, data) {
+    paths[i] = 'files/file-' + i;
+    fs.copyFile(paths[i], paths[i] + '.copy', function(err) {
       if (err)
         throw err;
-
-      t.equal(data, 'content')
     });
+  }
+
+  t.end();
+})
+
+test('read files', function (t) {
+  function expectContent(err, data) {
+    if (err)
+      throw err;
+
+    t.equal(data, 'content')
+  }
+
+  // now read them
+  t.plan(num * 2)
+  for (var i = 0; i < num; ++i) {
+    fs.readFile(paths[i], 'ascii', expectContent);
+    fs.readFile(paths[i] + '.copy', 'ascii', expectContent);
   }
 });
 


### PR DESCRIPTION
This PR adds support for `copyFile`, which can also return EMFILE
errors. I'm currently experiencing this via a third-party build tool that
copies many copies in parallel using `Promise.all`.

This PR also augments the `write-then-read` test to additionally copy
the written files and ensure that they exist and have the expected
content.

Resolves #122.