### PR TITLE
Support process.chdir.disabled

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -19,9 +19,7 @@ process.chdir = function(d) {
   cwd = null
   chdir.call(process, d)
 }
-if (chdir.disabled) {
- process.chdir.disabled = chdir.disabled
-}
+process.chdir.__proto__ = chdir
 
 module.exports = patch
 

--- a/polyfills.js
+++ b/polyfills.js
@@ -19,7 +19,7 @@ process.chdir = function(d) {
   cwd = null
   chdir.call(process, d)
 }
-process.chdir.__proto__ = chdir
+if (Object.setPrototypeOf) Object.setPrototypeOf(process.chdir, chdir)
 
 module.exports = patch
 

--- a/polyfills.js
+++ b/polyfills.js
@@ -19,6 +19,9 @@ process.chdir = function(d) {
   cwd = null
   chdir.call(process, d)
 }
+if (chdir.disabled) {
+ process.chdir.disabled = chdir.disabled
+}
 
 module.exports = patch
 


### PR DESCRIPTION
On more recent Node versions `process.chdir.disabled` is `true` in Workers (because that function isn't supported in worker threads). It was previously not copied over to the chdir wrapper.

Example (this issue causes an exception on Windows because https://github.com/moxystudio/node-cross-spawn/pull/132 need to check for `chdir.disabled`):

```js
// x.js
const {Worker} = require("worker_threads");
new Worker("./y.js");


// y.js
require('graceful-fs');
console.log(process.chdir.disabled, "should be true in a Worker"); // prints "undefined should ...."

const spawn = require('cross-spawn');
spawn('ps', [], {cwd: process.cwd()}) // this call fails on windows
```