### PR TITLE
Avoid hitting __proto__

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -7,7 +7,7 @@ function clone (obj) {
     return obj
 
   if (obj instanceof Object)
-    var copy = { __proto__: obj.__proto__ }
+    var copy = { __proto__: Object.getPrototypeOf(obj) }
   else
     var copy = Object.create(null)
 

--- a/clone.js
+++ b/clone.js
@@ -2,12 +2,16 @@
 
 module.exports = clone
 
+var getPrototypeOf = Object.getPrototypeOf || function (obj) {
+  return obj.__proto__
+}
+
 function clone (obj) {
   if (obj === null || typeof obj !== 'object')
     return obj
 
   if (obj instanceof Object)
-    var copy = { __proto__: Object.getPrototypeOf(obj) }
+    var copy = { __proto__: getPrototypeOf(obj) }
   else
     var copy = Object.create(null)
 

--- a/polyfills.js
+++ b/polyfills.js
@@ -132,7 +132,7 @@ function patch (fs) {
     }
 
     // This ensures `util.promisify` works as it does for native `fs.read`.
-    read.__proto__ = fs$read
+    if (Object.setPrototypeOf) Object.setPrototypeOf(read, fs$read)
     return read
   })(fs.read)
 


### PR DESCRIPTION
This avoids hitting `__proto__` for hardened environments where `__proto__` is disabled.

See discussion in https://github.com/nodejs/node/issues/31951 and https://github.com/nodejs/node/pull/32279.

To check that this works, run with `NODE_OPTIONS=--disable-proto=throw node -e 'require("./graceful-fs.js")'` before and after this change.

There is no reason to set `.read()` proto when `Object.setPrototypeOf` is not available, as no special handling of `util.promisify` exists on those versions (even if `util.promisify` is shipped separately somehow), so no `__proto__` fallback there.

This change works all the way down to 0.8 afaik — `Object.getPrototypeOf` is available there, and `Object.setPrototypeOf` is guarded. Have not checked on versions below 0.8.6.

I believe this could be a semver-minor or a semver-patch.