### PR TITLE
fix: copyFile with flags

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -173,10 +173,14 @@ function patch (fs) {
   var fs$copyFile = fs.copyFile
   if (fs$copyFile)
     fs.copyFile = copyFile
-  function copyFile (src, dest, cb) {
-    return fs$copyFile(src, dest, function (err) {
+  function copyFile (src, dest, flags, cb) {
+    if (typeof flags === 'function') {
+      cb = flags
+      flags = 0
+    }
+    return fs$copyFile(src, dest, flags, function (err) {
       if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-        enqueue([fs$copyFile, [src, dest, cb]])
+        enqueue([fs$copyFile, [src, dest, flags, cb]])
       else {
         if (typeof cb === 'function')
           cb.apply(this, arguments)

--- a/test/write-then-read.js
+++ b/test/write-then-read.js
@@ -36,6 +36,18 @@ test('copy files', function (t) {
   t.end();
 })
 
+test('copy files with flags', function (t) {
+  for (var i = 0; i < num; ++i) {
+    paths[i] = 'files/file-' + i;
+    fs.copyFile(paths[i], paths[i] + '.copy', 2, function(err) {
+      if (err)
+        throw err;
+    });
+  }
+
+  t.end();
+})
+
 test('read files', function (t) {
   function expectContent(err, data) {
     if (err)


### PR DESCRIPTION
If we call `fs.copyFile` with flags, the parameter `callback` misses:
```js
const fs = require('fs-extra'); // `fs.copyFile` called grancful-fs.copyFile

async function copy(src, dest) {
   console.log('start');
  await fs.copyFile(src, dest, fs.constants.COPYFILE_FICLONE);
  console.log('end'); // never get this line
}

copy(__filename, './another-file.js');

```
