### PR TITLE
Fix copyFile wrapper when retry() hits EMFILE again

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -178,15 +178,19 @@ function patch (fs) {
       cb = flags
       flags = 0
     }
-    return fs$copyFile(src, dest, flags, function (err) {
-      if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-        enqueue([fs$copyFile, [src, dest, flags, cb]])
-      else {
-        if (typeof cb === 'function')
-          cb.apply(this, arguments)
-        retry()
-      }
-    })
+    return go$copyFile(src, dest, flags, cb)
+
+    function go$copyFile (src, dest, flags, cb) {
+      return fs$copyFile(src, dest, flags, function (err) {
+        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
+          enqueue([go$copyFile, [src, dest, flags, cb]])
+        else {
+          if (typeof cb === 'function')
+            cb.apply(this, arguments)
+          retry()
+        }
+      })
+    }
   }
 
   var fs$readdir = fs.readdir


### PR DESCRIPTION
The `copyFile` wrapper introduced in #199 does not follow the same pattern as the other wrappers, and enqueued the _wrapped_ `copyFile` rather than the wrapper function, which means that a subsequent `EMFILE` or `ENFILE` error occurring when retrying the `copyFile` would fail and bubble the `EMFILE` or `ENFILE` to the calling code rather than enqueue again. This fix applies the same pattern by introducing `go$copyFile` and enqueueing it rather than `fs$copyFile`.

Fixes #208.

All tests pass and coverage goes up a bit (probably just because the new lines of test code are covered). I couldn't find tests that validate the `EMFILE` retry logic for the `fs` function wrappers (at least not for `copyFile`).