### PR TITLE
dont forget to retry

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -54,7 +54,7 @@ if (!fs[gracefulQueue]) {
       return fs$close.call(fs, fd, function (err) {
         // This function uses the graceful-fs shared queue
         if (!err) {
-          retry()
+          resetQueue()
         }
 
         if (typeof cb === 'function')
@@ -72,7 +72,7 @@ if (!fs[gracefulQueue]) {
     function closeSync (fd) {
       // This function uses the graceful-fs shared queue
       fs$closeSync.apply(fs, arguments)
-      retry()
+      resetQueue()
     }
 
     Object.defineProperty(closeSync, previousSymbol, {
@@ -114,14 +114,13 @@ function patch (fs) {
 
     return go$readFile(path, options, cb)
 
-    function go$readFile (path, options, cb) {
+    function go$readFile (path, options, cb, startTime) {
       return fs$readFile(path, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$readFile, [path, options, cb]])
+          enqueue([go$readFile, [path, options, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -135,14 +134,13 @@ function patch (fs) {
 
     return go$writeFile(path, data, options, cb)
 
-    function go$writeFile (path, data, options, cb) {
+    function go$writeFile (path, data, options, cb, startTime) {
       return fs$writeFile(path, data, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$writeFile, [path, data, options, cb]])
+          enqueue([go$writeFile, [path, data, options, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -157,14 +155,13 @@ function patch (fs) {
 
     return go$appendFile(path, data, options, cb)
 
-    function go$appendFile (path, data, options, cb) {
+    function go$appendFile (path, data, options, cb, startTime) {
       return fs$appendFile(path, data, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$appendFile, [path, data, options, cb]])
+          enqueue([go$appendFile, [path, data, options, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -180,14 +177,13 @@ function patch (fs) {
     }
     return go$copyFile(src, dest, flags, cb)
 
-    function go$copyFile (src, dest, flags, cb) {
+    function go$copyFile (src, dest, flags, cb, startTime) {
       return fs$copyFile(src, dest, flags, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$copyFile, [src, dest, flags, cb]])
+          enqueue([go$copyFile, [src, dest, flags, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -201,10 +197,10 @@ function patch (fs) {
 
     return go$readdir(path, options, cb)
 
-    function go$readdir (path, options, cb) {
+    function go$readdir (path, options, cb, startTime) {
       return fs$readdir(path, options, function (err, files) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$readdir, [path, options, cb]])
+          enqueue([go$readdir, [path, options, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (files && files.sort)
             files.sort()
@@ -338,14 +334,13 @@ function patch (fs) {
 
     return go$open(path, flags, mode, cb)
 
-    function go$open (path, flags, mode, cb) {
+    function go$open (path, flags, mode, cb, startTime) {
       return fs$open(path, flags, mode, function (err, fd) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$open, [path, flags, mode, cb]])
+          enqueue([go$open, [path, flags, mode, cb], err, startTime || Date.now(), Date.now()])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -357,12 +352,78 @@ function patch (fs) {
 function enqueue (elem) {
   debug('ENQUEUE', elem[0].name, elem[1])
   fs[gracefulQueue].push(elem)
+  retry()
+}
+
+// keep track of the timeout between retry() calls
+var retryTimer
+
+// reset the startTime and lastTime to now
+// this resets the start of the 60 second overall timeout as well as the
+// delay between attempts so that we'll retry these jobs sooner
+function resetQueue () {
+  var now = Date.now()
+  for (var i = 0; i < fs[gracefulQueue].length; ++i) {
+    // entries that are only a length of 2 are from an older version, don't
+    // bother modifying those since they'll be retried anyway.
+    if (fs[gracefulQueue][i].length > 2) {
+      fs[gracefulQueue][i][3] = now // startTime
+      fs[gracefulQueue][i][4] = now // lastTime
+    }
+  }
+  // call retry to make sure we're actively processing the queue
+  retry()
 }
 
 function retry () {
+  // clear the timer and remove it to help prevent unintended concurrency
+  clearTimeout(retryTimer)
+  retryTimer = undefined
+
+  if (fs[gracefulQueue].length === 0)
+    return
+
   var elem = fs[gracefulQueue].shift()
-  if (elem) {
-    debug('RETRY', elem[0].name, elem[1])
-    elem[0].apply(null, elem[1])
+  var fn = elem[0]
+  var args = elem[1]
+  // these items may be unset if they were added by an older graceful-fs
+  var err = elem[2]
+  var startTime = elem[3]
+  var lastTime = elem[4]
+
+  // if we don't have a startTime we have no way of knowing if we've waited
+  // long enough, so go ahead and retry this item now
+  if (startTime === undefined) {
+    debug('RETRY', fn.name, args)
+    fn.apply(null, args)
+  } else if (Date.now() - startTime >= 60000) {
+    // it's been more than 60 seconds total, bail now
+    debug('TIMEOUT', fn.name, args)
+    var cb = args.pop()
+    if (typeof cb === 'function')
+      cb.call(null, err)
+  } else {
+    // the amount of time between the last attempt and right now
+    var sinceAttempt = Date.now() - lastTime
+    // the amount of time between when we first tried, and when we last tried
+    // rounded up to at least 1
+    var sinceStart = Math.max(lastTime - startTime, 1)
+    // backoff. wait longer than the total time we've been retrying, but only
+    // up to a maximum of 100ms
+    var desiredDelay = Math.min(sinceStart * 1.2, 100)
+    // it's been long enough since the last retry, do it again
+    if (sinceAttempt >= desiredDelay) {
+      debug('RETRY', fn.name, args)
+      fn.apply(null, args.concat([startTime]))
+    } else {
+      // if we can't do this job yet, push it to the end of the queue
+      // and let the next iteration check again
+      fs[gracefulQueue].push(elem)
+    }
+  }
+
+  // schedule our next run if one isn't already scheduled
+  if (retryTimer === undefined) {
+    retryTimer = setTimeout(retry, 0)
   }
 }

--- a/test/readdir-sort.js
+++ b/test/readdir-sort.js
@@ -1,7 +1,7 @@
 var fs = require("fs")
 
 var readdir = fs.readdir
-fs.readdir = function(path, cb) {
+fs.readdir = function(path, options, cb) {
   process.nextTick(function() {
     cb(null, ["b", "z", "a"])
   })

--- a/test/retry.js
+++ b/test/retry.js
@@ -1,0 +1,36 @@
+'use strict'
+
+var importFresh = require('import-fresh')
+var path = require('path')
+var realFs = require('fs')
+var test = require('tap').test
+
+var EMFILE = Object.assign(new Error('FAKE EMFILE'), { code: 'EMFILE' })
+
+test('eventually times out and returns error', function (t) {
+  var readFile = realFs.readFile
+  var realNow = Date.now
+
+  t.teardown(function () {
+    realFs.readFile = readFile
+    Date.now = realNow
+  })
+
+  realFs.readFile = function (path, options, cb) {
+    process.nextTick(function () {
+      cb(EMFILE)
+      // hijack Date.now _after_ we call the callback, the callback will
+      // call it when adding the job to the queue, we want to capture it
+      // any time after that first call so we can pretend it's been 60s
+      Date.now = function () {
+        return realNow() + 60000
+      }
+    })
+  }
+
+  var fs = importFresh(path.dirname(__dirname))
+  fs.readFile('literally anything', function (err) {
+    t.equal(err.code, 'EMFILE', 'eventually got the EMFILE')
+    t.done()
+  })
+})


### PR DESCRIPTION
if a user is only running one fs operation at a time, and that operation fails with an EMFILE, we never call their callback. because of that the event loop no longer has anything to do and the entire process silently exits.

this change makes it so we start retrying an operation immediately, rather than waiting for another operation to finish successfully or `fs.close`/`fs.closeSync` to be called. in the callbacks for those, we now reset all state for everything in the queue and make sure the retry loop is running, this will make sure things retry sooner if they can.

the retry now keeps running every tick until the queue is empty. items are removed from the queue either when we retry them, or when they've reached a maximum of 60 seconds. this corrects the contract so that we will not stop trying to process the queue until every item in it has had its callback fired one way or another.