### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -231,7 +231,7 @@ function patch (fs) {
     }
   }
 
-  if (process.version.substr(0, 4) === 'v0.8') {
+  if (process.version.slice(0, 4) === 'v0.8') {
     var legStreams = legacy(fs)
     ReadStream = legStreams.ReadStream
     WriteStream = legStreams.WriteStream


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.