### PR TITLE
Fix : Problem with webpack 4 : Object prototype may only be an Object or null: undefined 

### DIFF
--- a/polyfills.js
+++ b/polyfills.js
@@ -136,7 +136,7 @@ function patch (fs) {
     }
 
     // This ensures `util.promisify` works as it does for native `fs.read`.
-    if (Object.setPrototypeOf) Object.setPrototypeOf(read, fs$read)
+    if (Object.setPrototypeOf && fs$read != undefined) Object.setPrototypeOf(read, fs$read)
     return read
   })(fs.read)
 


### PR DESCRIPTION
fixes issue: https://github.com/isaacs/node-graceful-fs/issues/222

https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea  does not support browser environment, so this PR fixed this issue.
This error occurs in version v4.2.5 or higher versions.

---
ref

Comparison of v4.2.4 and v4.2.5: https://github.com/isaacs/node-graceful-fs/compare/v4.2.4...v4.2.5





