### PR TITLE
Use "node:" prefixed imports everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,14 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x]
+        node-version: [14.8.0, 14, 16.0.0, 16]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          # Node 14 is not available on macos anymore
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 14.18.0
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -17,7 +23,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/graceful-fs.js
+++ b/graceful-fs.js
@@ -1,9 +1,9 @@
-var fs = require('fs')
+var fs = require('node:fs')
 var polyfills = require('./polyfills.js')
 var legacy = require('./legacy-streams.js')
 var clone = require('./clone.js')
 
-var util = require('util')
+var util = require('node:util')
 
 /* istanbul ignore next - node 0.x polyfill */
 var gracefulQueue
@@ -84,7 +84,7 @@ if (!fs[gracefulQueue]) {
   if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || '')) {
     process.on('exit', function() {
       debug(fs[gracefulQueue])
-      require('assert').equal(fs[gracefulQueue].length, 0)
+      require('node:assert').equal(fs[gracefulQueue].length, 0)
     })
   }
 }

--- a/legacy-streams.js
+++ b/legacy-streams.js
@@ -1,4 +1,4 @@
-var Stream = require('stream').Stream
+var Stream = require('node:stream').Stream
 
 module.exports = legacy
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "EACCESS"
   ],
   "license": "ISC",
+  "engines": {
+    "node": ">=14.18.0 <15 || >=16"
+  },
   "devDependencies": {
     "import-fresh": "^2.0.0",
     "mkdirp": "^0.5.0",

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,4 +1,4 @@
-var constants = require('constants')
+var constants = require('fs').constants
 
 var origCwd = process.cwd
 var cwd = null
@@ -31,7 +31,7 @@ function patch (fs) {
 
   // lchmod, broken prior to 0.6.2
   // back-port the fix here.
-  if (constants.hasOwnProperty('O_SYMLINK') &&
+  if (constants.O_SYMLINK !== undefined &&
       process.version.match(/^v0\.6\.[0-2]|^v0\.5\./)) {
     patchLchmod(fs)
   }
@@ -206,7 +206,7 @@ function patch (fs) {
   }
 
   function patchLutimes (fs) {
-    if (constants.hasOwnProperty("O_SYMLINK") && fs.futimes) {
+    if (constants.O_SYMLINK !== undefined && fs.futimes) {
       fs.lutimes = function (path, at, mt, cb) {
         fs.open(path, constants.O_SYMLINK, function (er, fd) {
           if (er) {

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,4 +1,4 @@
-var constants = require('fs').constants
+var constants = require('node:fs').constants
 
 var origCwd = process.cwd
 var cwd = null

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
-var fs = require('fs')
+var fs = require('node:fs')
 var tap = require('tap')
 var dir = __dirname + '/test'
 var node = process.execPath
-var path = require('path')
+var path = require('node:path')
 
 var files = fs.readdirSync(dir)
 var env = Object.keys(process.env).reduce(function (env, k) {
@@ -12,7 +12,7 @@ var env = Object.keys(process.env).reduce(function (env, k) {
   TEST_GRACEFUL_FS_GLOBAL_PATCH: 1
 })
 
-tap.jobs = require('os').cpus().length
+tap.jobs = require('node:os').cpus().length
 var testFiles = files.filter(function (f) {
   return (/\.js$/.test(f) && fs.statSync(dir + '/' + f).isFile())
 })

--- a/test/chown-er-ok.js
+++ b/test/chown-er-ok.js
@@ -1,4 +1,4 @@
-var realFs = require('fs')
+var realFs = require('node:fs')
 
 var methods = ['chown', 'chownSync', 'chmod', 'chmodSync']
 methods.forEach(function (method) {

--- a/test/close.js
+++ b/test/close.js
@@ -1,5 +1,5 @@
-var fs = require('fs')
-var path = require('path')
+var fs = require('node:fs')
+var path = require('node:path')
 var gfsPath = path.resolve(__dirname, '..', 'graceful-fs.js')
 var gfs = require(gfsPath)
 var importFresh = require('import-fresh')

--- a/test/monkeypatch-by-accident.js
+++ b/test/monkeypatch-by-accident.js
@@ -5,7 +5,7 @@ if (process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH) {
   process.exit(0)
 }
 
-const fs = require('fs')
+const fs = require('node:fs')
 
 // Save originals before loading graceful-fs
 const names = [

--- a/test/read-write-stream.js
+++ b/test/read-write-stream.js
@@ -8,7 +8,7 @@ var t = require('tap')
 var td = t.testdir({
   files: {}
 })
-var p = require('path').resolve(td, 'files')
+var p = require('node:path').resolve(td, 'files')
 
 process.chdir(td)
 

--- a/test/readfile.js
+++ b/test/readfile.js
@@ -8,7 +8,7 @@ var t = require('tap')
 var td = t.testdir({
   files: {}
 })
-var p = require('path').resolve(td, 'files')
+var p = require('node:path').resolve(td, 'files')
 
 process.chdir(td)
 

--- a/test/retry.js
+++ b/test/retry.js
@@ -1,8 +1,8 @@
 'use strict'
 
 var importFresh = require('import-fresh')
-var path = require('path')
-var realFs = require('fs')
+var path = require('node:path')
+var realFs = require('node:fs')
 var test = require('tap').test
 
 var EMFILE = Object.assign(new Error('FAKE EMFILE'), { code: 'EMFILE' })

--- a/test/stats-uid-gid.js
+++ b/test/stats-uid-gid.js
@@ -1,6 +1,6 @@
 'use strict';
-var util = require('util')
-var fs = require('fs')
+var util = require('node:util')
+var fs = require('node:fs')
 var test = require('tap').test
 
 // mock fs.statSync to return signed uids/gids

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,4 +1,4 @@
-var fs = require('fs')
+var fs = require('node:fs')
 var gfs = require('../graceful-fs.js')
 var test = require('tap').test
 

--- a/test/windows-rename-polyfill.js
+++ b/test/windows-rename-polyfill.js
@@ -1,7 +1,7 @@
 process.env.GRACEFUL_FS_PLATFORM = 'win32'
 var t = require('tap')
 
-var fs = require('fs')
+var fs = require('node:fs')
 
 var ers = ['EPERM', 'EBUSY', 'EACCES']
 t.plan(ers.length)

--- a/test/write-then-read.js
+++ b/test/write-then-read.js
@@ -4,7 +4,7 @@ var mkdirp = require('mkdirp')
 var t = require('tap')
 
 var td = t.testdir({ files: {} })
-var p = require('path').resolve(td, 'files')
+var p = require('node:path').resolve(td, 'files')
 
 process.chdir(td)
 

--- a/test/zzz-avoid-memory-leak.js
+++ b/test/zzz-avoid-memory-leak.js
@@ -2,7 +2,7 @@ var importFresh = require('import-fresh');
 var t = require('tap')
 var v8
 try {
-  v8 = require('v8')
+  v8 = require('node:v8')
 } catch (er) {}
 
 if (!v8 || !v8.getHeapStatistics || typeof v8.getHeapStatistics().number_of_detached_contexts !== 'number') {


### PR DESCRIPTION
This allows this package to be used with runtimes other than node, where node compatibility layer is provided for the prefixed imports (e.g. `workerd`), at the cost of leaving behind older nodejs versions.

Specifically, the required nodejs version would become ">=14.18.0 <15 || >=16".

CI is updated accordingly.

This PR also includes the first commit of #206. There was a conflict with master that's resolved, which is why the commit is unverified. The fallback introduced in that PR's second commit is not included, because given the version bump this PR requires, compatibility with those node versions is no longer needed.