### PR TITLE
README.md: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ patched.  It is safe to use in all versions of Node from 0.8 through
 * Close #4 Chown should not fail on einval or eperm if non-root
 * Fix isaacs/fstream#1 Only wrap fs one time
 * Fix #3 Start at 1024 max files, then back off on EMFILE
-* lutimes that doens't blow up on Linux
+* lutimes that doesn't blow up on Linux
 * A full on-rewrite using a queue instead of just swallowing the EMFILE error
 * Wrap Read/Write streams as well
 


### PR DESCRIPTION
```diff
- * lutimes that doens't blow up on Linux
+ * lutimes that doesn't blow up on Linux
```